### PR TITLE
feature #4

### DIFF
--- a/src/app/api/progress.py
+++ b/src/app/api/progress.py
@@ -9,7 +9,7 @@ from sqlmodel.ext.asyncio.session import AsyncSession
 
 from app.core.dependencies import CurrentActiveUser
 from app.database import get_session
-from app.models import ReviewRequest, UserCardProgressRead
+from app.models import NewCardsCountRead, ReviewRequest, UserCardProgressRead
 from app.services.user_card_progress_service import UserCardProgressService
 
 router = APIRouter(prefix="/progress", tags=["progress"])
@@ -62,3 +62,15 @@ async def get_card_progress(
             detail="Progress not found for this card",
         )
     return progress
+
+
+@router.get("/new-cards-count", response_model=NewCardsCountRead)
+async def get_new_cards_count(
+    session: Annotated[AsyncSession, Depends(get_session)] = None,
+    current_user: CurrentActiveUser = None,
+):
+    """Get count of new cards and review cards based on user's selected decks."""
+    count_data = await UserCardProgressService.get_new_cards_count(
+        session, current_user.id
+    )
+    return NewCardsCountRead(**count_data)

--- a/src/app/models/__init__.py
+++ b/src/app/models/__init__.py
@@ -25,6 +25,7 @@ from app.models.schemas import (
     DeckUpdate,
     FavoriteCreate,
     FavoriteRead,
+    NewCardsCountRead,
     ReviewRequest,
     UserCreate,
     UserLogin,
@@ -69,6 +70,7 @@ __all__ = [
     "UserCardProgressCreate",
     "UserCardProgressRead",
     "ReviewRequest",
+    "NewCardsCountRead",
     # Deck Schemas
     "DeckCreate",
     "DeckRead",

--- a/src/app/models/schemas/__init__.py
+++ b/src/app/models/schemas/__init__.py
@@ -2,6 +2,7 @@ from app.models.schemas.deck import DeckCreate, DeckRead, DeckUpdate
 from app.models.schemas.favorite import FavoriteCreate, FavoriteRead
 from app.models.schemas.user import UserCreate, UserLogin, UserRead, UserUpdate
 from app.models.schemas.user_card_progress import (
+    NewCardsCountRead,
     ReviewRequest,
     UserCardProgressCreate,
     UserCardProgressRead,
@@ -30,6 +31,7 @@ __all__ = [
     "UserCardProgressCreate",
     "UserCardProgressRead",
     "ReviewRequest",
+    "NewCardsCountRead",
     # Deck
     "DeckCreate",
     "DeckRead",

--- a/src/app/models/schemas/user_card_progress.py
+++ b/src/app/models/schemas/user_card_progress.py
@@ -30,3 +30,10 @@ class ReviewRequest(SQLModel):
 
     card_id: int = Field(gt=0, description="Card ID must be positive")
     is_correct: bool
+
+
+class NewCardsCountRead(SQLModel):
+    """Schema for reading new and review cards count."""
+
+    new_cards_count: int
+    review_cards_count: int


### PR DESCRIPTION
## Changes
- ✅ `GET /api/v1/progress/new-cards-count` 엔드포인트 추가
- ✅ `NewCardsCountRead` 스키마 생성
- ✅ `UserCardProgressService.get_new_cards_count()` 메서드 구현
- ✅ 아직 학습하지 않은 새 카드 개수 조회
- ✅ 복습 대기 중인 카드 개수 조회
- ✅ 사용자의 덱 선택 설정 자동 반영 (select_all_decks)
- ✅ select_all_decks=true: 모든 public 덱에서 카운트
- ✅ select_all_decks=false: user_selected_decks에서만 카운트