### PR TITLE
feat: implement remaining APIs (stats, user config, user level)

### DIFF
--- a/src/app/api/stats.py
+++ b/src/app/api/stats.py
@@ -2,9 +2,10 @@
 Stats-related API endpoints.
 """
 
-from typing import Annotated
+from datetime import UTC, datetime, timedelta
+from typing import Annotated, Literal
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, Query
 from sqlmodel import func, select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
@@ -12,7 +13,13 @@ from app.core.dependencies import CurrentActiveUser
 from app.database import get_session
 from app.models import UserCardProgress, VocabularyCard
 from app.models.enums import CardState
-from app.models.schemas.stats import TotalLearnedRead
+from app.models.schemas.stats import (
+    AccuracyByPeriod,
+    StatsAccuracyRead,
+    StatsHistoryItem,
+    StatsHistoryRead,
+    TotalLearnedRead,
+)
 
 router = APIRouter(prefix="/stats", tags=["stats"])
 
@@ -57,4 +64,168 @@ async def get_total_learned(
         total_learned=total_learned,
         by_level=by_level,
         total_study_time_minutes=current_user.total_study_time_minutes,
+    )
+
+
+@router.get("/history", response_model=StatsHistoryRead)
+async def get_stats_history(
+    current_user: CurrentActiveUser,
+    session: Annotated[AsyncSession, Depends(get_session)],
+    period: Literal["7d", "30d", "90d", "1y"] = Query(default="30d", description="Time period"),
+):
+    """
+    Get study history for charts.
+
+    Returns daily statistics including cards studied, correct count, and accuracy rate.
+    """
+    # Calculate date range based on period
+    now = datetime.now(UTC)
+    period_days = {"7d": 7, "30d": 30, "90d": 90, "1y": 365}
+    days = period_days[period]
+    start_date = now - timedelta(days=days)
+
+    # Query for daily stats grouped by date
+    # Using correct_count and total_reviews from UserCardProgress
+    history_query = (
+        select(
+            func.date(UserCardProgress.last_review_date).label("review_date"),
+            func.sum(UserCardProgress.total_reviews).label("cards_studied"),
+            func.sum(UserCardProgress.correct_count).label("correct_count"),
+        )
+        .where(
+            UserCardProgress.user_id == current_user.id,
+            UserCardProgress.last_review_date >= start_date,
+            UserCardProgress.last_review_date.isnot(None),
+        )
+        .group_by(func.date(UserCardProgress.last_review_date))
+        .order_by(func.date(UserCardProgress.last_review_date).asc())
+    )
+
+    result = await session.exec(history_query)
+    rows = result.all()
+
+    # Build history items
+    history_data = []
+    for row in rows:
+        review_date, cards_studied, correct_count = row
+        cards_studied = cards_studied or 0
+        correct_count = correct_count or 0
+        accuracy = (correct_count / cards_studied * 100) if cards_studied > 0 else 0.0
+
+        history_data.append(
+            StatsHistoryItem(
+                date=review_date,
+                cards_studied=cards_studied,
+                correct_count=correct_count,
+                accuracy_rate=round(accuracy, 1),
+            )
+        )
+
+    return StatsHistoryRead(period=period, data=history_data)
+
+
+@router.get("/accuracy", response_model=StatsAccuracyRead)
+async def get_stats_accuracy(
+    current_user: CurrentActiveUser,
+    session: Annotated[AsyncSession, Depends(get_session)],
+):
+    """
+    Get accuracy statistics.
+
+    Returns overall accuracy, accuracy by time period, and accuracy by CEFR level.
+    """
+    now = datetime.now(UTC)
+
+    # Helper function to calculate accuracy for a period
+    async def get_accuracy_for_period(days: int | None) -> tuple[int, int]:
+        """Returns (total_reviews, correct_count) for the given period."""
+        query = select(
+            func.sum(UserCardProgress.total_reviews),
+            func.sum(UserCardProgress.correct_count),
+        ).where(UserCardProgress.user_id == current_user.id)
+
+        if days is not None:
+            start_date = now - timedelta(days=days)
+            query = query.where(UserCardProgress.last_review_date >= start_date)
+
+        result = await session.exec(query)
+        row = result.one()
+        return (row[0] or 0, row[1] or 0)
+
+    # Get all-time stats
+    total_reviews, total_correct = await get_accuracy_for_period(None)
+    overall_accuracy = (total_correct / total_reviews * 100) if total_reviews > 0 else 0.0
+
+    # Get period-based stats
+    reviews_7d, correct_7d = await get_accuracy_for_period(7)
+    reviews_30d, correct_30d = await get_accuracy_for_period(30)
+    reviews_90d, correct_90d = await get_accuracy_for_period(90)
+
+    accuracy_7d = (correct_7d / reviews_7d * 100) if reviews_7d > 0 else None
+    accuracy_30d = (correct_30d / reviews_30d * 100) if reviews_30d > 0 else None
+    accuracy_90d = (correct_90d / reviews_90d * 100) if reviews_90d > 0 else None
+
+    by_period = AccuracyByPeriod(
+        all_time=round(overall_accuracy, 1),
+        last_7_days=round(accuracy_7d, 1) if accuracy_7d is not None else None,
+        last_30_days=round(accuracy_30d, 1) if accuracy_30d is not None else None,
+        last_90_days=round(accuracy_90d, 1) if accuracy_90d is not None else None,
+    )
+
+    # Get accuracy by CEFR level
+    by_level_query = (
+        select(
+            VocabularyCard.cefr_level,
+            func.sum(UserCardProgress.total_reviews),
+            func.sum(UserCardProgress.correct_count),
+        )
+        .select_from(UserCardProgress)
+        .join(VocabularyCard, VocabularyCard.id == UserCardProgress.card_id)
+        .where(
+            UserCardProgress.user_id == current_user.id,
+            VocabularyCard.cefr_level.isnot(None),
+        )
+        .group_by(VocabularyCard.cefr_level)
+    )
+    result = await session.exec(by_level_query)
+    by_level_rows = result.all()
+
+    by_cefr_level = {}
+    for level, reviews, correct in by_level_rows:
+        if reviews and reviews > 0:
+            by_cefr_level[level] = round((correct or 0) / reviews * 100, 1)
+
+    # Determine trend (comparing last 7 days vs previous 7 days)
+    trend = "stable"
+    if accuracy_7d is not None:
+        # Get accuracy for 8-14 days ago
+        prev_start = now - timedelta(days=14)
+        prev_end = now - timedelta(days=7)
+        prev_query = select(
+            func.sum(UserCardProgress.total_reviews),
+            func.sum(UserCardProgress.correct_count),
+        ).where(
+            UserCardProgress.user_id == current_user.id,
+            UserCardProgress.last_review_date >= prev_start,
+            UserCardProgress.last_review_date < prev_end,
+        )
+        result = await session.exec(prev_query)
+        prev_row = result.one()
+        prev_reviews, prev_correct = prev_row[0] or 0, prev_row[1] or 0
+
+        if prev_reviews > 0:
+            prev_accuracy = prev_correct / prev_reviews * 100
+            diff = accuracy_7d - prev_accuracy
+            if diff > 5:
+                trend = "improving"
+            elif diff < -5:
+                trend = "declining"
+
+    return StatsAccuracyRead(
+        overall_accuracy=round(overall_accuracy, 1),
+        total_reviews=total_reviews,
+        total_correct=total_correct,
+        by_period=by_period,
+        by_cefr_level=by_cefr_level,
+        trend=trend,
     )

--- a/src/app/models/__init__.py
+++ b/src/app/models/__init__.py
@@ -6,6 +6,7 @@ from app.models.enums import CardState
 
 # Schemas (DTOs)
 from app.models.schemas import (
+    AccuracyByPeriod,
     DailyGoalRead,
     DailyGoalStatus,
     DeckCreate,
@@ -28,12 +29,18 @@ from app.models.schemas import (
     SessionStartRequest,
     SessionStartResponse,
     SessionSummary,
+    StatsAccuracyRead,
+    StatsHistoryItem,
+    StatsHistoryRead,
     StreakInfo,
     StreakRead,
     TodayProgressRead,
     UserCardProgressCreate,
     UserCardProgressRead,
+    UserConfigRead,
+    UserConfigUpdate,
     UserCreate,
+    UserLevelRead,
     UserLogin,
     UserRead,
     UserSelectedDeckCreate,
@@ -82,6 +89,9 @@ __all__ = [
     "UserLogin",
     "DailyGoalRead",
     "StreakRead",
+    "UserConfigRead",
+    "UserConfigUpdate",
+    "UserLevelRead",
     # VocabularyCard Schemas
     "VocabularyCardCreate",
     "VocabularyCardRead",
@@ -109,6 +119,11 @@ __all__ = [
     "SelectDecksResponse",
     "SelectedDeckInfo",
     "GetSelectedDecksResponse",
+    # Stats Schemas
+    "StatsHistoryRead",
+    "StatsHistoryItem",
+    "StatsAccuracyRead",
+    "AccuracyByPeriod",
     # Study Session Schemas
     "SessionCompleteRequest",
     "SessionCompleteResponse",

--- a/src/app/models/schemas/__init__.py
+++ b/src/app/models/schemas/__init__.py
@@ -7,7 +7,13 @@ from app.models.schemas.deck import (
     DeckWithProgressRead,
 )
 from app.models.schemas.favorite import FavoriteCreate, FavoriteRead
-from app.models.schemas.stats import TotalLearnedRead
+from app.models.schemas.stats import (
+    AccuracyByPeriod,
+    StatsAccuracyRead,
+    StatsHistoryItem,
+    StatsHistoryRead,
+    TotalLearnedRead,
+)
 from app.models.schemas.study import (
     DailyGoalStatus,
     SessionCard,
@@ -21,7 +27,10 @@ from app.models.schemas.study import (
 from app.models.schemas.user import (
     DailyGoalRead,
     StreakRead,
+    UserConfigRead,
+    UserConfigUpdate,
     UserCreate,
+    UserLevelRead,
     UserLogin,
     UserRead,
     UserUpdate,
@@ -55,6 +64,9 @@ __all__ = [
     "UserLogin",
     "DailyGoalRead",
     "StreakRead",
+    "UserConfigRead",
+    "UserConfigUpdate",
+    "UserLevelRead",
     # VocabularyCard
     "VocabularyCardCreate",
     "VocabularyCardRead",
@@ -84,6 +96,10 @@ __all__ = [
     "GetSelectedDecksResponse",
     # Stats
     "TotalLearnedRead",
+    "StatsHistoryRead",
+    "StatsHistoryItem",
+    "StatsAccuracyRead",
+    "AccuracyByPeriod",
     # Study Session
     "SessionCompleteRequest",
     "SessionCompleteResponse",

--- a/src/app/models/schemas/stats.py
+++ b/src/app/models/schemas/stats.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from sqlmodel import SQLModel
 
 
@@ -7,3 +9,39 @@ class TotalLearnedRead(SQLModel):
     total_learned: int
     by_level: dict[str, int]
     total_study_time_minutes: int
+
+
+class StatsHistoryItem(SQLModel):
+    """Schema for a single day's study history."""
+
+    date: date
+    cards_studied: int
+    correct_count: int
+    accuracy_rate: float
+
+
+class StatsHistoryRead(SQLModel):
+    """Schema for reading study history (for charts)."""
+
+    period: str  # "7d", "30d", "90d", "1y"
+    data: list[StatsHistoryItem]
+
+
+class AccuracyByPeriod(SQLModel):
+    """Schema for accuracy statistics by time period."""
+
+    all_time: float
+    last_7_days: float | None = None
+    last_30_days: float | None = None
+    last_90_days: float | None = None
+
+
+class StatsAccuracyRead(SQLModel):
+    """Schema for reading accuracy statistics."""
+
+    overall_accuracy: float
+    total_reviews: int
+    total_correct: int
+    by_period: AccuracyByPeriod
+    by_cefr_level: dict[str, float]  # e.g., {"A1": 85.0, "A2": 78.5}
+    trend: str  # "improving", "stable", "declining"

--- a/src/app/models/schemas/user.py
+++ b/src/app/models/schemas/user.py
@@ -91,3 +91,44 @@ class StreakRead(SQLModel):
     days_studied_this_month: int
     streak_status: str  # "active" or "broken"
     message: str
+
+
+class UserConfigRead(SQLModel):
+    """Schema for reading user configuration/settings."""
+
+    daily_goal: int
+    select_all_decks: bool
+    timezone: str
+    theme: str
+    notification_enabled: bool
+
+
+class UserConfigUpdate(SQLModel):
+    """Schema for updating user configuration/settings."""
+
+    daily_goal: int | None = Field(default=None, gt=0, le=1000)
+    select_all_decks: bool | None = None
+    timezone: str | None = Field(default=None, max_length=50)
+    theme: str | None = Field(default=None, max_length=20)
+    notification_enabled: bool | None = None
+
+    @field_validator("theme")
+    @classmethod
+    def theme_valid(cls, v: str | None) -> str | None:
+        """Validate theme is one of the allowed values."""
+        if v is None:
+            return v
+        allowed_themes = {"light", "dark", "auto"}
+        if v not in allowed_themes:
+            raise ValueError(f"Theme must be one of: {', '.join(allowed_themes)}")
+        return v
+
+
+class UserLevelRead(SQLModel):
+    """Schema for reading user's calculated level."""
+
+    level: float  # 1.0 - 10.0
+    cefr_equivalent: str  # A1-C2
+    total_reviews: int
+    accuracy_rate: float
+    mastered_cards: int


### PR DESCRIPTION
## Summary
- Add stats endpoints: `/stats/history`, `/stats/accuracy`, `/stats/total-learned`
- Add user config endpoints: `GET/PUT /users/me/config`
- Add user level endpoint: `GET /users/me/level` with CEFR calculation
- Add user streak endpoint: `GET /users/me/streak`

## Related Issues
Closes #12, Closes #13, Closes #14, Closes #15, Closes #20

## Changes
- `src/app/api/stats.py`: Implement history, accuracy, total-learned endpoints
- `src/app/api/users.py`: Add config, level, streak endpoints
- `src/app/models/schemas/stats.py`: Add stats response schemas
- `src/app/models/schemas/user.py`: Add config and level schemas
- `src/app/services/user_service.py`: Add daily goal and user level calculation logic

## Test plan
- [ ] Test `/stats/history` with different periods (7d, 30d, 90d, 1y)
- [ ] Test `/stats/accuracy` returns correct overall and by-period accuracy
- [ ] Test `/users/me/config` GET and PUT operations
- [ ] Test `/users/me/level` returns valid CEFR level
- [ ] Test `/users/me/streak` returns correct streak info

🤖 Generated with [Claude Code](https://claude.com/claude-code)